### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ To use it, install the [ArduinoHTS221 library](https://www.arduino.cc/en/Referen
 ### Measuring barometric pressure with the Nano
 The Arduino Nano 33 BLE Sense has a barometric pressure sensor, the [LPS22HB](https://www.st.com/resource/en/datasheet/lps22hb.pdf).
 
-To use it, install the [ArduinoLPS22HB library](https://www.arduino.cc/en/Reference/ArduinoLPS22HB) and check the [examples](https://github.com/arduino-libraries/ArduinoLPS22HB/blob/master/examples).
+To use it, install the [ArduinoLPS22HB library](https://www.arduino.cc/en/Reference/ArduinoLPS22HB) and check the [examples](https://github.com/arduino-libraries/Arduino_LPS22HB/blob/master/examples).
 
 ### Measuring orientation in space of the Nano
 The Arduino Nano 33 BLE Sense has a 9-axis inertial measuring unit (IMU) built-in.
 
 The [LSM9DS1](https://www.st.com/resource/en/datasheet/lsm9ds1.pdf) includes an accelerometer, a gyroscope and a magnetometer.
 
-To use it, install the [ArduinoLSM9DS1 library](https://www.arduino.cc/en/Reference/ArduinoLSM9DS1) and check the [examples](https://github.com/arduino-libraries/ArduinoLSM9DS1/blob/master/examples).
+To use it, install the [ArduinoLSM9DS1 library](https://www.arduino.cc/en/Reference/ArduinoLSM9DS1) and check the [examples](https://github.com/arduino-libraries/Arduino_LSM9DS1/blob/master/examples).
 
 ### Measuring noise and recording audio with the Nano
 The Arduino Nano 33 BLE Sense has a built-in microphone, the [MP34DT05](https://www.st.com/resource/en/datasheet/mp34dt05-a.pdf) which outputs [PDM signals](https://en.wikipedia.org/wiki/Pulse-density_modulation).
@@ -81,7 +81,7 @@ The Arduino Nano 33 BLE Sense has a light intensity sensor, the [APDS9960](https
 
 The multifunctional sensor can detect gestures, light color and proximity.
 
-To use it, install the [ArduinoAPDS9960 library](https://www.arduino.cc/en/Reference/ArduinoAPDS9960) and check the [examples](https://github.com/arduino-libraries/ArduinoAPDS9960/blob/master/examples).
+To use it, install the [ArduinoAPDS9960 library](https://www.arduino.cc/en/Reference/ArduinoAPDS9960) and check the [examples](https://github.com/arduino-libraries/Arduino_APDS9960/blob/master/examples).
 
 ### Measuring TVOC and CO2 with the Sensirion ESS-C3 shield
 The [Sensirion ESS-C3 shield](https://developer.sensirion.com/platforms/environmental-sensor-shield/) has environmental sensors to measure temperature, humidity, TVOC and CO2.


### PR DESCRIPTION
Wrong links to some Arduino examples (Missing underscores). Links now corrected